### PR TITLE
Making messaging entities serializable

### DIFF
--- a/platforms/common-kord/build.gradle.kts
+++ b/platforms/common-kord/build.gradle.kts
@@ -1,7 +1,6 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     kotlin("jvm")
+    kotlin("plugin.serialization") version "1.5.10"
     `maven-publish`
 }
 

--- a/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordEditedOriginalInteractionEphemeralMessage.kt
+++ b/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordEditedOriginalInteractionEphemeralMessage.kt
@@ -4,12 +4,16 @@ import dev.kord.common.entity.DiscordMessage
 import dev.kord.common.entity.Snowflake
 import dev.kord.rest.builder.message.modify.InteractionResponseModifyBuilder
 import dev.kord.rest.service.RestClient
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
 import net.perfectdreams.discordinteraktions.common.builder.message.modify.EphemeralInteractionOrFollowupMessageModifyBuilder
 import net.perfectdreams.discordinteraktions.common.builder.message.modify.EphemeralMessageModifyBuilder
 import net.perfectdreams.discordinteraktions.common.entities.messages.EditableEphemeralMessage
 import net.perfectdreams.discordinteraktions.platforms.kord.utils.runIfNotMissing
 
+@Serializable
 class KordEditedOriginalInteractionEphemeralMessage(
+    @Contextual
     private val rest: RestClient,
     private val applicationId: Snowflake,
     private val interactionToken: String,

--- a/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordEditedOriginalInteractionPublicMessage.kt
+++ b/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordEditedOriginalInteractionPublicMessage.kt
@@ -4,12 +4,16 @@ import dev.kord.common.entity.DiscordMessage
 import dev.kord.common.entity.Snowflake
 import dev.kord.rest.builder.message.modify.FollowupMessageModifyBuilder
 import dev.kord.rest.service.RestClient
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
 import net.perfectdreams.discordinteraktions.common.builder.message.modify.PersistentMessageModifyBuilder
 import net.perfectdreams.discordinteraktions.common.builder.message.modify.PublicInteractionOrFollowupMessageModifyBuilder
 import net.perfectdreams.discordinteraktions.common.entities.messages.EditablePersistentMessage
 import net.perfectdreams.discordinteraktions.platforms.kord.utils.runIfNotMissing
 
+@Serializable
 class KordEditedOriginalInteractionPublicMessage(
+    @Contextual
     private val rest: RestClient,
     private val applicationId: Snowflake,
     private val interactionToken: String,

--- a/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordEphemeralFollowupMessage.kt
+++ b/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordEphemeralFollowupMessage.kt
@@ -4,13 +4,17 @@ import dev.kord.common.entity.DiscordMessage
 import dev.kord.common.entity.Snowflake
 import dev.kord.rest.builder.message.modify.FollowupMessageModifyBuilder
 import dev.kord.rest.service.RestClient
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
 import net.perfectdreams.discordinteraktions.common.builder.message.modify.EphemeralInteractionOrFollowupMessageModifyBuilder
 import net.perfectdreams.discordinteraktions.common.builder.message.modify.EphemeralMessageModifyBuilder
 import net.perfectdreams.discordinteraktions.common.entities.messages.EditableEphemeralMessage
 import net.perfectdreams.discordinteraktions.common.entities.messages.EphemeralMessage
 import net.perfectdreams.discordinteraktions.platforms.kord.utils.runIfNotMissing
 
+@Serializable
 open class KordEphemeralFollowupMessage(
+    @Contextual
     private val rest: RestClient,
     private val applicationId: Snowflake,
     private val interactionToken: String,

--- a/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordEphemeralMessage.kt
+++ b/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordEphemeralMessage.kt
@@ -1,10 +1,10 @@
 package net.perfectdreams.discordinteraktions.platforms.kord.entities.messages
 
 import dev.kord.common.entity.DiscordMessage
-import net.perfectdreams.discordinteraktions.common.builder.message.modify.EphemeralInteractionOrFollowupMessageModifyBuilder
-import net.perfectdreams.discordinteraktions.common.builder.message.modify.EphemeralMessageModifyBuilder
+import kotlinx.serialization.Serializable
 import net.perfectdreams.discordinteraktions.common.entities.messages.EphemeralMessage
 
+@Serializable
 open class KordEphemeralMessage(val handle: DiscordMessage) : EphemeralMessage {
     override val id = handle.id
     override val content by handle::content

--- a/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordOriginalInteractionEphemeralMessage.kt
+++ b/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordOriginalInteractionEphemeralMessage.kt
@@ -3,13 +3,17 @@ package net.perfectdreams.discordinteraktions.platforms.kord.entities.messages
 import dev.kord.common.entity.Snowflake
 import dev.kord.rest.builder.message.modify.InteractionResponseModifyBuilder
 import dev.kord.rest.service.RestClient
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
 import net.perfectdreams.discordinteraktions.common.builder.message.modify.EphemeralInteractionOrFollowupMessageModifyBuilder
 import net.perfectdreams.discordinteraktions.common.builder.message.modify.EphemeralMessageModifyBuilder
 import net.perfectdreams.discordinteraktions.common.entities.messages.EditableEphemeralMessage
 import net.perfectdreams.discordinteraktions.common.entities.messages.EphemeralMessage
 import net.perfectdreams.discordinteraktions.platforms.kord.utils.runIfNotMissing
 
+@Serializable
 class KordOriginalInteractionEphemeralMessage(
+    @Contextual
     private val rest: RestClient,
     private val applicationId: Snowflake,
     private val interactionToken: String,

--- a/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordOriginalInteractionPublicMessage.kt
+++ b/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordOriginalInteractionPublicMessage.kt
@@ -3,13 +3,17 @@ package net.perfectdreams.discordinteraktions.platforms.kord.entities.messages
 import dev.kord.common.entity.Snowflake
 import dev.kord.rest.builder.message.modify.InteractionResponseModifyBuilder
 import dev.kord.rest.service.RestClient
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
 import net.perfectdreams.discordinteraktions.common.builder.message.modify.PersistentMessageModifyBuilder
 import net.perfectdreams.discordinteraktions.common.builder.message.modify.PublicInteractionOrFollowupMessageModifyBuilder
 import net.perfectdreams.discordinteraktions.common.entities.messages.EditablePersistentMessage
 import net.perfectdreams.discordinteraktions.common.entities.messages.PublicMessage
 import net.perfectdreams.discordinteraktions.platforms.kord.utils.runIfNotMissing
 
+@Serializable
 class KordOriginalInteractionPublicMessage(
+    @Contextual
     private val rest: RestClient,
     private val applicationId: Snowflake,
     private val interactionToken: String,

--- a/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordPublicFollowupMessage.kt
+++ b/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordPublicFollowupMessage.kt
@@ -4,13 +4,17 @@ import dev.kord.common.entity.DiscordMessage
 import dev.kord.common.entity.Snowflake
 import dev.kord.rest.builder.message.modify.FollowupMessageModifyBuilder
 import dev.kord.rest.service.RestClient
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
 import net.perfectdreams.discordinteraktions.common.builder.message.modify.PersistentMessageModifyBuilder
 import net.perfectdreams.discordinteraktions.common.builder.message.modify.PublicInteractionOrFollowupMessageModifyBuilder
 import net.perfectdreams.discordinteraktions.common.entities.messages.EditablePersistentMessage
 import net.perfectdreams.discordinteraktions.common.entities.messages.PublicMessage
 import net.perfectdreams.discordinteraktions.platforms.kord.utils.runIfNotMissing
 
+@Serializable
 class KordPublicFollowupMessage(
+    @Contextual
     private val rest: RestClient,
     private val applicationId: Snowflake,
     private val interactionToken: String,

--- a/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordPublicMessage.kt
+++ b/platforms/common-kord/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/entities/messages/KordPublicMessage.kt
@@ -1,10 +1,10 @@
 package net.perfectdreams.discordinteraktions.platforms.kord.entities.messages
 
 import dev.kord.common.entity.DiscordMessage
-import net.perfectdreams.discordinteraktions.common.builder.message.modify.PersistentMessageModifyBuilder
-import net.perfectdreams.discordinteraktions.common.builder.message.modify.PublicInteractionOrFollowupMessageModifyBuilder
+import kotlinx.serialization.Serializable
 import net.perfectdreams.discordinteraktions.common.entities.messages.PublicMessage
 
+@Serializable
 open class KordPublicMessage(val handle: DiscordMessage) : PublicMessage {
     override val id = handle.id
     override val content by handle::content


### PR DESCRIPTION
Because some messages do not have ID, that is, they cannot be left to be edited/deleted later unless they are saved in some way, and this way would be serializing them to be easier to handle after a while.