### PR TITLE
Detect parent class via Reflection, refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ object CharacterCommand : SlashCommandDeclarationWrapper {
 }
 
 class CharacterExecutor : SlashCommandExecutor() {
-    companion object : SlashCommandExecutorDeclaration(CharacterExecutor::class) { // This needs to be a class reference to the executor class!
+    companion object : SlashCommandExecutorDeclaration() { // This needs to be a class reference to the executor class!
         // By default, if you don't override the options, no options will be set
         override val options = Option
 
@@ -227,7 +227,7 @@ Add the Kord Web Server via Ktor Support module to your project
 ```kotlin
 dependencies {
     ...
-    implementation("net.perfectdreams.discordinteraktions:webserver-ktor-kord:0.0.13-SNAPSHOT") // Check latest version in https://github.com/LorittaBot/DiscordInteraKTions/blob/main/buildSrc/src/main/kotlin/Versions.kt
+    implementation("net.perfectdreams.discordinteraktions:webserver-ktor-kord:0.0.14-SNAPSHOT") // Check latest version in https://github.com/LorittaBot/DiscordInteraKTions/blob/main/settings.gradle.kts#L15
     ...
 }
 ```
@@ -282,7 +282,7 @@ Add the Kord Gateway Support module to your project
 ```kotlin
 dependencies {
     ...
-    implementation("net.perfectdreams.discordinteraktions:gateway-kord:0.0.13-SNAPSHOT") // Check latest version in https://github.com/LorittaBot/DiscordInteraKTions/blob/main/buildSrc/src/main/kotlin/Versions.kt
+    implementation("net.perfectdreams.discordinteraktions:gateway-kord:0.0.14-SNAPSHOT") // Check latest version in https://github.com/LorittaBot/DiscordInteraKTions/blob/main/settings.gradle.kts#L15
     ...
 }
 ```

--- a/common/src/main/kotlin/net/perfectdreams/discordinteraktions/common/autocomplete/AutocompleteExecutorDeclarations.kt
+++ b/common/src/main/kotlin/net/perfectdreams/discordinteraktions/common/autocomplete/AutocompleteExecutorDeclarations.kt
@@ -1,14 +1,23 @@
 package net.perfectdreams.discordinteraktions.common.autocomplete
 
+import net.perfectdreams.discordinteraktions.platforms.kord.commands.CommandDeclarationUtils
+
 sealed class AutocompleteExecutorDeclaration<T>(
     /**
-     * The "parent" is Any to avoid issues with anonymous classes
+     * The [parent] is Any? to avoid issues with anonymous classes
      *
      * When using anonymous classes, you can use another type to match declarations
+     *
+     * If [parent] is null when the class is initialized, the declaration will try to find the parent by using Reflection!
      */
-    val parent: Any
-)
+    var parent: Any? = null
+) {
+    init {
+        if (parent == null)
+            parent = CommandDeclarationUtils.getParentClass(this)
+    }
+}
 
-open class StringAutocompleteExecutorDeclaration(parent: Any) : AutocompleteExecutorDeclaration<String>(parent)
-open class IntegerAutocompleteExecutorDeclaration(parent: Any) : AutocompleteExecutorDeclaration<Long>(parent)
-open class NumberAutocompleteExecutorDeclaration(parent: Any) : AutocompleteExecutorDeclaration<Double>(parent)
+open class StringAutocompleteExecutorDeclaration(parent: Any? = null) : AutocompleteExecutorDeclaration<String>(parent)
+open class IntegerAutocompleteExecutorDeclaration(parent: Any? = null) : AutocompleteExecutorDeclaration<Long>(parent)
+open class NumberAutocompleteExecutorDeclaration(parent: Any? = null) : AutocompleteExecutorDeclaration<Double>(parent)

--- a/common/src/main/kotlin/net/perfectdreams/discordinteraktions/common/commands/ApplicationCommandExecutorDeclarations.kt
+++ b/common/src/main/kotlin/net/perfectdreams/discordinteraktions/common/commands/ApplicationCommandExecutorDeclarations.kt
@@ -1,15 +1,26 @@
 package net.perfectdreams.discordinteraktions.common.commands
 
 import net.perfectdreams.discordinteraktions.common.commands.options.ApplicationCommandOptions
+import net.perfectdreams.discordinteraktions.platforms.kord.commands.CommandDeclarationUtils
 
-// The "parent" is Any to avoid issues with anonymous classes
-// When using anonymous classes, you can use another type to match declarations
-sealed class ApplicationCommandExecutorDeclaration(val parent: Any)
+/**
+ * The [parent] is Any? to avoid issues with anonymous classes
+ *
+ * When using anonymous classes, you can use another type to match declarations
+ *
+ * If [parent] is null when the class is initialized, the declaration will try to find the parent by using Reflection!
+ */
+sealed class ApplicationCommandExecutorDeclaration(var parent: Any? = null) {
+    init {
+        if (parent == null)
+            parent = CommandDeclarationUtils.getParentClass(this)
+    }
+}
 
-open class SlashCommandExecutorDeclaration(parent: Any) : ApplicationCommandExecutorDeclaration(parent) {
+open class SlashCommandExecutorDeclaration(parent: Any? = null) : ApplicationCommandExecutorDeclaration(parent) {
     open val options: ApplicationCommandOptions = ApplicationCommandOptions.NO_OPTIONS
 }
 
-open class UserCommandExecutorDeclaration(parent: Any) : ApplicationCommandExecutorDeclaration(parent)
+open class UserCommandExecutorDeclaration(parent: Any? = null) : ApplicationCommandExecutorDeclaration(parent)
 
-open class MessageCommandExecutorDeclaration(parent: Any) : ApplicationCommandExecutorDeclaration(parent)
+open class MessageCommandExecutorDeclaration(parent: Any? = null) : ApplicationCommandExecutorDeclaration(parent)

--- a/common/src/main/kotlin/net/perfectdreams/discordinteraktions/common/commands/CommandManager.kt
+++ b/common/src/main/kotlin/net/perfectdreams/discordinteraktions/common/commands/CommandManager.kt
@@ -3,18 +3,15 @@ package net.perfectdreams.discordinteraktions.common.commands
 import net.perfectdreams.discordinteraktions.common.autocomplete.AutocompleteExecutor
 import net.perfectdreams.discordinteraktions.common.autocomplete.AutocompleteExecutorDeclaration
 import net.perfectdreams.discordinteraktions.common.components.ButtonClickBaseExecutor
-import net.perfectdreams.discordinteraktions.common.components.ButtonClickExecutor
 import net.perfectdreams.discordinteraktions.common.components.ButtonClickExecutorDeclaration
 import net.perfectdreams.discordinteraktions.common.components.SelectMenuBaseExecutor
-import net.perfectdreams.discordinteraktions.common.components.SelectMenuExecutor
 import net.perfectdreams.discordinteraktions.common.components.SelectMenuExecutorDeclaration
 import net.perfectdreams.discordinteraktions.common.modals.ModalSubmitBaseExecutor
-import net.perfectdreams.discordinteraktions.common.modals.ModalSubmitExecutor
 import net.perfectdreams.discordinteraktions.common.modals.ModalSubmitExecutorDeclaration
 
 open class CommandManager {
-    val declarations = mutableListOf<ApplicationCommandDeclaration>()
-    val executors = mutableListOf<ApplicationCommandExecutor>()
+    val applicationCommandsDeclarations = mutableListOf<ApplicationCommandDeclaration>()
+    val applicationCommandsExecutors = mutableListOf<ApplicationCommandExecutor>()
 
     val buttonDeclarations = mutableListOf<ButtonClickExecutorDeclaration>()
     val buttonExecutors = mutableListOf<ButtonClickBaseExecutor>()
@@ -31,15 +28,16 @@ open class CommandManager {
     val componentDeclarations: List<String>
         get() = buttonDeclarations.map { it.id } + selectMenusDeclarations.map { it.id }
 
-    fun register(declarationWrapper: ApplicationCommandDeclarationWrapper, vararg executors: ApplicationCommandExecutor) {
-        // TODO: Validate if all executors of the command are present
-        val declaration = declarationWrapper.declaration()
+    fun register(declarationWrapper: ApplicationCommandDeclarationWrapper, vararg executors: ApplicationCommandExecutor) =
+        register(declarationWrapper.declaration(), *executors)
 
-        if (declarations.any { it.name == declaration.name })
+    fun register(declaration: ApplicationCommandDeclaration, vararg executors: ApplicationCommandExecutor) {
+        // TODO: Validate if all executors of the command are present
+        if (applicationCommandsDeclarations.any { it.name == declaration.name })
             error("There's already an root command registered with the label ${declaration.name}!")
 
-        declarations.add(declaration)
-        this.executors.addAll(executors)
+        applicationCommandsDeclarations.add(declaration)
+        this.applicationCommandsExecutors.addAll(executors)
     }
 
     fun register(declaration: ButtonClickExecutorDeclaration, executor: ButtonClickBaseExecutor) {

--- a/common/src/main/kotlin/net/perfectdreams/discordinteraktions/common/components/ComponentExecutorDeclarations.kt
+++ b/common/src/main/kotlin/net/perfectdreams/discordinteraktions/common/components/ComponentExecutorDeclarations.kt
@@ -1,12 +1,16 @@
 package net.perfectdreams.discordinteraktions.common.components
 
+import net.perfectdreams.discordinteraktions.platforms.kord.commands.CommandDeclarationUtils
+
 sealed class ComponentExecutorDeclaration(
     /**
-     * The "parent" is Any to avoid issues with anonymous classes
+     * The [parent] is Any? to avoid issues with anonymous classes
      *
      * When using anonymous classes, you can use another type to match declarations
+     *
+     * If [parent] is null when the class is initialized, the declaration will try to find the parent by using Reflection!
      */
-    val parent: Any,
+    var parent: Any? = null,
 
     /**
      * The executor's ID, this is stored in the button, to be able to figure out what executor should be used
@@ -24,21 +28,30 @@ sealed class ComponentExecutorDeclaration(
      */
     idRegex: Regex = ID_REGEX
 ) {
+    constructor(id: String, idRegex: Regex = ID_REGEX) : this(null, id, idRegex)
+
     companion object {
         val ID_REGEX = Regex("[A-z0-9]+")
     }
 
     init {
         require(idRegex.matches(id)) { "ID must respect the $ID_REGEX regular expression!" }
+
+        if (parent == null)
+            parent = CommandDeclarationUtils.getParentClass(this)
     }
 }
 
 open class ButtonClickExecutorDeclaration(
-    parent: Any,
+    parent: Any? = null,
     id: String
-) : ComponentExecutorDeclaration(parent, id)
+) : ComponentExecutorDeclaration(parent, id) {
+    constructor(id: String) : this(null, id)
+}
 
 open class SelectMenuExecutorDeclaration(
-    parent: Any,
+    parent: Any? = null,
     id: String
-) : ComponentExecutorDeclaration(parent, id)
+) : ComponentExecutorDeclaration(parent, id) {
+    constructor(id: String) : this(null, id)
+}

--- a/common/src/main/kotlin/net/perfectdreams/discordinteraktions/common/modals/ModalSubmitExecutorDeclaration.kt
+++ b/common/src/main/kotlin/net/perfectdreams/discordinteraktions/common/modals/ModalSubmitExecutorDeclaration.kt
@@ -1,17 +1,20 @@
 package net.perfectdreams.discordinteraktions.common.modals
 
-import net.perfectdreams.discordinteraktions.common.commands.options.ApplicationCommandOptions
+import net.perfectdreams.discordinteraktions.common.components.ComponentExecutorDeclaration
 import net.perfectdreams.discordinteraktions.common.components.ComponentExecutorDeclaration.Companion.ID_REGEX
 import net.perfectdreams.discordinteraktions.common.modals.ModalSubmitExecutorDeclaration.Companion.ID_REGEX
 import net.perfectdreams.discordinteraktions.common.modals.components.ModalComponents
+import net.perfectdreams.discordinteraktions.platforms.kord.commands.CommandDeclarationUtils
 
 open class ModalSubmitExecutorDeclaration(
     /**
-     * The "parent" is Any to avoid issues with anonymous classes
+     * The [parent] is Any? to avoid issues with anonymous classes
      *
      * When using anonymous classes, you can use another type to match declarations
+     *
+     * If [parent] is null when the class is initialized, the declaration will try to find the parent by using Reflection!
      */
-    val parent: Any,
+    var parent: Any? = null,
 
     /**
      * The executor's ID, this is stored in the modal, to be able to figure out what executor should be used
@@ -29,12 +32,17 @@ open class ModalSubmitExecutorDeclaration(
      */
     idRegex: Regex = ID_REGEX
 ) {
+    constructor(id: String, idRegex: Regex = ID_REGEX) : this(null, id, idRegex)
+
     companion object {
         val ID_REGEX = Regex("[A-z0-9]+")
     }
 
     init {
         require(idRegex.matches(id)) { "ID must respect the $ID_REGEX regular expression!" }
+
+        if (parent == null)
+            parent = CommandDeclarationUtils.getParentClass(this)
     }
 
     open val options: ModalComponents = object: ModalComponents() {}

--- a/common/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/commands/KordCommandRegistry.kt
+++ b/common/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/commands/KordCommandRegistry.kt
@@ -12,7 +12,7 @@ class KordCommandRegistry(private val applicationId: Snowflake, private val rest
         rest.interaction.createGuildApplicationCommands(
             applicationId,
             guildId,
-            manager.declarations.map {
+            manager.applicationCommandsDeclarations.map {
                 convertCommandDeclarationToKord(it).toRequest()
             }
         )
@@ -23,7 +23,7 @@ class KordCommandRegistry(private val applicationId: Snowflake, private val rest
 
         rest.interaction.createGlobalApplicationCommands(
             kordApplicationId,
-            manager.declarations.map {
+            manager.applicationCommandsDeclarations.map {
                 convertCommandDeclarationToKord(it).toRequest()
             }
         )

--- a/common/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/utils/KordCommandChecker.kt
+++ b/common/src/main/kotlin/net/perfectdreams/discordinteraktions/platforms/kord/utils/KordCommandChecker.kt
@@ -87,7 +87,7 @@ class KordCommandChecker(val commandManager: CommandManager) {
                     ?: InteraKTionsExceptions.missingDeclaration("slash command")
 
                 val executorDeclaration = command.executor ?: return
-                val executor = commandManager.executors.firstOrNull {
+                val executor = commandManager.applicationCommandsExecutors.firstOrNull {
                     it.signature() == executorDeclaration.parent
                 } as SlashCommandExecutor? ?: InteraKTionsExceptions.missingExecutor("slash command")
 
@@ -114,7 +114,7 @@ class KordCommandChecker(val commandManager: CommandManager) {
                     ?: InteraKTionsExceptions.missingDeclaration("user command")
 
                 val executorDeclaration = command.executor
-                val executor = commandManager.executors.firstOrNull {
+                val executor = commandManager.applicationCommandsExecutors.firstOrNull {
                     it.signature() == executorDeclaration.parent
                 } as UserCommandExecutor? ?: InteraKTionsExceptions.missingExecutor("user command")
 
@@ -133,7 +133,7 @@ class KordCommandChecker(val commandManager: CommandManager) {
                     ?: InteraKTionsExceptions.missingDeclaration("message command")
 
                 val executorDeclaration = command.executor
-                val executor = commandManager.executors.firstOrNull {
+                val executor = commandManager.applicationCommandsExecutors.firstOrNull {
                     it.signature() == executorDeclaration.parent
                 } as MessageCommandExecutor? ?: InteraKTionsExceptions.missingExecutor("message command")
 

--- a/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/AutocompleteFunAutocompleteExecutor.kt
+++ b/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/AutocompleteFunAutocompleteExecutor.kt
@@ -6,7 +6,7 @@ import net.perfectdreams.discordinteraktions.common.autocomplete.StringAutocompl
 import net.perfectdreams.discordinteraktions.common.autocomplete.StringAutocompleteExecutorDeclaration
 
 class AutocompleteFunAutocompleteExecutor : StringAutocompleteExecutor {
-    companion object : StringAutocompleteExecutorDeclaration(AutocompleteFunAutocompleteExecutor::class)
+    companion object : StringAutocompleteExecutorDeclaration()
 
     override suspend fun onAutocomplete(
         context: AutocompleteContext,

--- a/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/AutocompleteFunExecutor.kt
+++ b/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/AutocompleteFunExecutor.kt
@@ -7,7 +7,7 @@ import net.perfectdreams.discordinteraktions.common.commands.options.Application
 import net.perfectdreams.discordinteraktions.common.commands.options.SlashCommandArguments
 
 class AutocompleteFunExecutor : SlashCommandExecutor() {
-    companion object : SlashCommandExecutorDeclaration(AutocompleteFunExecutor::class) {
+    companion object : SlashCommandExecutorDeclaration() {
         object Options : ApplicationCommandOptions() {
             val text = string("text", "Text")
                 .register()

--- a/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/ButtonsExecutor.kt
+++ b/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/ButtonsExecutor.kt
@@ -9,7 +9,7 @@ import net.perfectdreams.discordinteraktions.common.commands.options.SlashComman
 import net.perfectdreams.discordinteraktions.common.components.interactiveButton
 
 class ButtonsExecutor : SlashCommandExecutor() {
-    companion object : SlashCommandExecutorDeclaration(ButtonsExecutor::class)
+    companion object : SlashCommandExecutorDeclaration()
 
     override suspend fun execute(context: ApplicationCommandContext, args: SlashCommandArguments) {
         context.sendMessage {

--- a/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/CounterButtonClickExecutor.kt
+++ b/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/CounterButtonClickExecutor.kt
@@ -8,7 +8,7 @@ import net.perfectdreams.discordinteraktions.common.entities.User
 
 class CounterButtonClickExecutor(private val counter: Counter) : ButtonClickExecutor {
     // All buttons must have unique IDs!
-    companion object : ButtonClickExecutorDeclaration(CounterButtonClickExecutor::class, "counter")
+    companion object : ButtonClickExecutorDeclaration("counter")
 
     override suspend fun onClick(user: User, context: ComponentContext) {
         val newCount = counter.addAndGet()

--- a/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/CounterExecutor.kt
+++ b/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/CounterExecutor.kt
@@ -16,8 +16,7 @@ import net.perfectdreams.discordinteraktions.common.components.interactiveButton
 import net.perfectdreams.discordinteraktions.common.entities.messages.editMessage
 
 class CounterExecutor(private val counter: Counter) : SlashCommandExecutor() {
-    companion object : SlashCommandExecutorDeclaration(CounterExecutor::class) {
-
+    companion object : SlashCommandExecutorDeclaration() {
         fun createCounterMessage(currentCount: Int): MessageBuilder.() -> (Unit) = {
             content = """Current count: $currentCount
                 |

--- a/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/FancyButtonClickExecutor.kt
+++ b/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/FancyButtonClickExecutor.kt
@@ -7,7 +7,7 @@ import net.perfectdreams.discordinteraktions.common.entities.User
 
 class FancyButtonClickExecutor : ButtonClickWithDataExecutor {
     // All buttons must have unique IDs!
-    companion object : ButtonClickExecutorDeclaration(FancyButtonClickExecutor::class, "fancy_button")
+    companion object : ButtonClickExecutorDeclaration("fancy_button")
 
     override suspend fun onClick(user: User, context: ComponentContext, data: String) {
         context.sendEphemeralMessage {

--- a/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/HelloWorldExecutor.kt
+++ b/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/HelloWorldExecutor.kt
@@ -6,7 +6,7 @@ import net.perfectdreams.discordinteraktions.common.commands.SlashCommandExecuto
 import net.perfectdreams.discordinteraktions.common.commands.options.SlashCommandArguments
 
 class HelloWorldExecutor : SlashCommandExecutor() {
-    companion object : SlashCommandExecutorDeclaration(HelloWorldExecutor::class)
+    companion object : SlashCommandExecutorDeclaration()
 
     override suspend fun execute(context: ApplicationCommandContext, args: SlashCommandArguments) {
         context.sendMessage {

--- a/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/ModalSubmitYayExecutor.kt
+++ b/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/ModalSubmitYayExecutor.kt
@@ -8,7 +8,7 @@ import net.perfectdreams.discordinteraktions.common.modals.components.ModalArgum
 import net.perfectdreams.discordinteraktions.common.modals.components.ModalComponents
 
 class ModalSubmitYayExecutor : ModalSubmitExecutor {
-    companion object : ModalSubmitExecutorDeclaration(ModalSubmitYayExecutor::class, "modal_submit_example") {
+    companion object : ModalSubmitExecutorDeclaration("modal_submit_example") {
         object Options : ModalComponents() {
             val something = textInput("something")
                 .register()

--- a/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/SendModalExecutor.kt
+++ b/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/SendModalExecutor.kt
@@ -8,7 +8,7 @@ import net.perfectdreams.discordinteraktions.common.commands.options.SlashComman
 import net.perfectdreams.discordinteraktions.common.modals.components.textInput
 
 class SendModalExecutor : SlashCommandExecutor() {
-    companion object : SlashCommandExecutorDeclaration(SendModalExecutor::class)
+    companion object : SlashCommandExecutorDeclaration()
 
     override suspend fun execute(context: ApplicationCommandContext, args: SlashCommandArguments) {
         context.sendModal(ModalSubmitYayExecutor, "Hello World!!") {

--- a/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/SendYourAttachmentExecutor.kt
+++ b/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/SendYourAttachmentExecutor.kt
@@ -10,7 +10,7 @@ import net.perfectdreams.discordinteraktions.common.commands.options.SlashComman
 import net.perfectdreams.discordinteraktions.common.components.interactiveButton
 
 class SendYourAttachmentExecutor : SlashCommandExecutor() {
-    companion object : SlashCommandExecutorDeclaration(SendYourAttachmentExecutor::class) {
+    companion object : SlashCommandExecutorDeclaration() {
         object Options : ApplicationCommandOptions() {
             val attachment = attachment("attachment", "Your attachment")
                 .register()

--- a/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/declarations/AutocompleteFunAutocompleteExecutor.kt
+++ b/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/commands/declarations/AutocompleteFunAutocompleteExecutor.kt
@@ -1,2 +1,0 @@
-package com.mrpowergamerbr.nicolebot.commands.declarations
-

--- a/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/utils/Counter.kt
+++ b/sample/src/main/kotlin/com/mrpowergamerbr/nicolebot/utils/Counter.kt
@@ -18,6 +18,6 @@ class Counter(
     }
 
     suspend fun addAndGet() = mutex.withLock {
-        count++
+        ++count
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ include(":sample")
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
-            version("discordinteraktions", "0.0.13-SNAPSHOT")
+            version("discordinteraktions", "0.0.14-SNAPSHOT")
             version("kotlin", "1.6.20")
             version("kord", "0.8.x-20220414.234246-171")
             alias("kord-common").to("dev.kord", "kord-common").versionRef("kord")


### PR DESCRIPTION
This PR tries to simplify Discord InteraKTions a bit, because one of the things that always "gets" me is those classes in the companion object for declarations. This PR fixes this by allowing the class to be found via Reflection.